### PR TITLE
Handle inlined literals

### DIFF
--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -58,6 +58,7 @@ def phase_compile_library_for_plugin_bootstrapping(ctx, p):
             for target in p.scalac_provider.default_classpath + ctx.attr.exports
         ],
         unused_dependency_checker_mode = "off",
+        buildijar = ctx.attr.build_ijar,
     )
     return _phase_compile_default(ctx, p, args)
 

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -161,6 +161,8 @@ _scala_library_for_plugin_bootstrapping_attrs.update(
     common_attrs_for_plugin_bootstrapping,
 )
 
+_scala_library_for_plugin_bootstrapping_attrs["build_ijar"] = attr.bool(default = True)
+
 def make_scala_library_for_plugin_bootstrapping(*extras):
     return rule(
         attrs = _dicts.add(

--- a/third_party/dependency_analyzer/src/main/BUILD
+++ b/third_party/dependency_analyzer/src/main/BUILD
@@ -3,6 +3,21 @@ licenses(["notice"])  # 3-clause BSD
 load("//scala:scala.bzl", "scala_library_for_plugin_bootstrapping")
 
 scala_library_for_plugin_bootstrapping(
+    name = "scala_version",
+    srcs = [
+        "io/bazel/rulesscala/dependencyanalyzer/ScalaVersion.scala",
+    ],
+    # As this contains macros we shouldn't make an ijar
+    build_ijar = False,
+    resources = ["resources/scalac-plugin.xml"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
+    ],
+)
+
+scala_library_for_plugin_bootstrapping(
     name = "dependency_analyzer",
     srcs = [
         "io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala",
@@ -14,6 +29,7 @@ scala_library_for_plugin_bootstrapping(
     resources = ["resources/scalac-plugin.xml"],
     visibility = ["//visibility:public"],
     deps = [
+        ":scala_version",
         "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
         "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
     ],

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
@@ -37,6 +37,20 @@ class AstUsedJarFinder(
             node.original.foreach(fullyExploreTree)
           }
         case node: Literal =>
+          // We should examine OriginalTreeAttachment but that was only
+          // added in 2.12.4, so include a version check
+          ScalaVersion.conditional(
+            "2.12.4",
+            "",
+            """
+              node.attachments
+                .get[global.treeChecker.OriginalTreeAttachment]
+                .foreach { attach =>
+                  fullyExploreTree(attach.original)
+                }
+            """
+          )
+
           node.value.value match {
             case tpe: Type =>
               exploreType(tpe)

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/ScalaVersion.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/ScalaVersion.scala
@@ -1,0 +1,112 @@
+package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+object ScalaVersion {
+  val Current: ScalaVersion = ScalaVersion(util.Properties.versionNumberString)
+
+  def apply(versionString: String): ScalaVersion = {
+    versionString.split("\\.") match {
+      case Array(superMajor, major, minor) =>
+        new ScalaVersion(superMajor.toInt, major.toInt, minor.toInt)
+      case _ =>
+        throw new Exception(s"Failed to parse version $versionString")
+    }
+  }
+
+  /**
+   * Runs [code] only if minVersion and maxVersion constraints are met.
+   *
+   * NOTE: This method should be used only rarely. Most of the time
+   * just comparing versions in code should be enough. This is needed
+   * only when the code we want to run can't compile under certain
+   * versions. The reason to use this rarely is the API's inflexibility
+   * and the difficulty in debugging this code.
+   *
+   * Each of minVersion and maxVersion can either be the empty string ("")
+   * to signify that there is no restriction on this bound.
+   *
+   * Or it can be a string of a full version number such as "2.12.10".
+   *
+   * Note only literal strings are accepted, no variables etc. i.e.
+   *
+   * valid:
+   *  conditional(minVersion = "2.12.4", maxVersion = "", code = "foo()")
+   * invalid:
+   *  conditional(minVersion = MinVersionForFoo, maxVersion = "", code = "foo()")
+   */
+  def conditional(
+    minVersion: String,
+    maxVersion: String,
+    code: String
+  ): Unit =
+    macro conditionalImpl
+
+  def conditionalImpl(
+    c: blackbox.Context
+  )(
+    minVersion: c.Expr[String],
+    maxVersion: c.Expr[String],
+    code: c.Expr[String]
+  ): c.Tree = {
+    import c.{universe => u}
+    import u.Quasiquote
+    def extractString(expr: c.Expr[String]): String = {
+      expr.tree match {
+        case u.Literal(u.Constant(s: String)) =>
+          s
+        case _ =>
+          c.error(
+            expr.tree.pos,
+            "Parameter must be passed as a string literal such as \"2.12.10\"")
+          ""
+      }
+    }
+
+    val meetsMinVersionRequirement = {
+      val minVersionStr = extractString(minVersion)
+      minVersionStr == "" || Current >= ScalaVersion(minVersionStr)
+    }
+
+    val meetsMaxVersionRequirement = {
+      val maxVersionStr = extractString(maxVersion)
+      maxVersionStr == "" || Current <= ScalaVersion(maxVersionStr)
+    }
+
+    if (meetsMinVersionRequirement && meetsMaxVersionRequirement) {
+      c.parse(extractString(code))
+    } else {
+      q""
+    }
+  }
+}
+
+class ScalaVersion private(
+  private val superMajor: Int,
+  private val major: Int,
+  private val minor: Int
+) extends Ordered[ScalaVersion] {
+  override def compare(that: ScalaVersion): Int = {
+    if (this.superMajor != that.superMajor) {
+      this.superMajor.compareTo(that.superMajor)
+    } else if (this.major != that.major) {
+      this.major.compareTo(that.major)
+    } else {
+      this.minor.compareTo(that.minor)
+    }
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case that: ScalaVersion =>
+        compare(that) == 0
+      case _ =>
+        false
+    }
+  }
+
+  override def toString: String = {
+    s"$superMajor.$major.$minor"
+  }
+}

--- a/third_party/dependency_analyzer/src/test/BUILD
+++ b/third_party/dependency_analyzer/src/test/BUILD
@@ -14,14 +14,26 @@ scala_test(
         "io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala",
     ],
     jvm_flags = common_jvm_flags,
-    unused_dependency_checker_mode = "off",
     deps = [
-        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
         "//external:io_bazel_rules_scala/dependency/scala/scala_library",
         "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
         "//third_party/dependency_analyzer/src/main:dependency_analyzer",
+        "//third_party/dependency_analyzer/src/main:scala_version",
         "//third_party/utils/src/test:test_util",
         "@scalac_rules_commons_io//jar",
+    ],
+)
+
+scala_test(
+    name = "scala_version_test",
+    size = "small",
+    srcs = [
+        "io/bazel/rulesscala/dependencyanalyzer/ScalaVersionTest.scala",
+    ],
+    deps = [
+        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
+        "//third_party/dependency_analyzer/src/main:scala_version",
     ],
 )
 

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalaVersionTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalaVersionTest.scala
@@ -1,0 +1,136 @@
+package third_party.dependency_analyzer.src.test.io.bazel.rulesscala.dependencyanalyzer
+
+import org.scalatest._
+import third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.ScalaVersion
+
+class ScalaVersionTest extends FunSuite {
+  test("version comparison works") {
+    // i.e. a>b
+    def testGreater(a: String, b: String): Unit = {
+      val va = ScalaVersion(a)
+      val vb = ScalaVersion(b)
+
+      assert(!(va == vb))
+      assert(va != vb)
+      assert(!(va < vb))
+      assert(!(va <= vb))
+      assert(va > vb)
+      assert(va >= vb)
+
+      // Lesser versions
+      assert(!(vb == va))
+      assert(vb != va)
+      assert(vb < va)
+      assert(vb <= va)
+      assert(!(vb > va))
+      assert(!(vb >= va))
+    }
+
+    def testEqual(a: String, b: String): Unit = {
+      val va = ScalaVersion(a)
+      val vb = ScalaVersion(b)
+
+      assert(va == vb)
+      assert(!(va != vb))
+      assert(!(va < vb))
+      assert(va <= vb)
+      assert(!(va > vb))
+      assert(va >= vb)
+    }
+
+    testEqual("1.1.1", "1.1.1")
+    testEqual("1.2.3", "1.2.3")
+    testEqual("30.20.10", "30.20.10")
+
+    testGreater("1.2.3", "1.0.0")
+    testGreater("1.2.1", "1.2.0")
+    testGreater("1.2.0", "1.1.9")
+    testGreater("2.12.12", "2.12.11")
+    testGreater("2.12.0", "2.1.50")
+  }
+
+  test("macro works") {
+    // These are rather duplicative unfortunately as the person
+    // who wrote the macro is not very smart
+
+    // We use versions like 1.0.0 and 500.0.0 so that even
+    // as versions of scala change the test won't need to be updated
+
+    // No bounds
+    {
+      var hit = false
+      ScalaVersion.conditional(
+        "",
+        "",
+        "hit = true"
+      )
+      assert(hit)
+    }
+
+    // Min bounds hit
+    {
+      var hit = false
+      ScalaVersion.conditional(
+        "1.0.0",
+        "",
+        "hit = true"
+      )
+      assert(hit)
+    }
+
+    // Min bounds not hit
+    {
+      var hit = false
+      ScalaVersion.conditional(
+        "500.0.0",
+        "",
+        "hit = true"
+      )
+      assert(!hit)
+    }
+
+    // Max bounds hit
+    {
+      var hit = false
+      ScalaVersion.conditional(
+        "",
+        "500.0.0",
+        "hit = true"
+      )
+      assert(hit)
+    }
+
+    // Min bounds not hit
+    {
+      var hit = false
+      ScalaVersion.conditional(
+        "",
+        "0.0.0",
+        "hit = true"
+      )
+      assert(!hit)
+    }
+
+    // Min-max bound hit
+    {
+      var hit = false
+      ScalaVersion.conditional(
+        "0.0.0",
+        "500.0.0",
+        "hit = true"
+      )
+      assert(hit)
+    }
+
+    // Min-max bound not hit
+    {
+      var hit = false
+      ScalaVersion.conditional(
+        "500.0.0",
+        "1000.0.0",
+        "hit = true"
+      )
+      assert(!hit)
+    }
+  }
+}


### PR DESCRIPTION
### Description
We update the AST-based dependency analyzer mode to properly handle literals which were inlined.

This fixes the issue only for Scala 2.12.4+. The functionality we are using to fix this only exists in 2.12.4+

We also introduce `ScalaVersion` to make handling versions easier as well as allowing a very primitive conditional compilation via macro. As we now have a macro, we make minor adjustments to make macros work in `scala_library_for_plugin_bootstrapping`.

### Motivation
This removes a false positive in the AST checker.
